### PR TITLE
Error messages obfuscation rework

### DIFF
--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -14,12 +14,12 @@ const login = catchAsync(async (req, res, next) => {
 
   const user = await User.findOne({email});
   if (!user) {
-    return next(new ApiError(httpStatus.UNAUTHORIZED, `User ${email} is not registered`));
+    return next(new ApiError(httpStatus.UNAUTHORIZED, `Invalid username or password`));
   }
 
   const correctPassword = await compare(password, user.password);
   if (!correctPassword) {
-    return next(new ApiError(httpStatus.UNAUTHORIZED, `Password ${password} is not correct for user ${email}`));
+    return next(new ApiError(httpStatus.UNAUTHORIZED, `Invalid username or password`));
   }
 
   logIn(req, user.id, user.email, user.role);
@@ -40,7 +40,7 @@ const checkin = catchAsync(async (req, res, next) => {
   const user = await User.findById(userId);
   if (!user) {
     await logOut(req, res);
-    return next(new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'User is not found. Removing the session'));
+    return next(new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'User is not found. Removing the session', {obfuscate: true}));
   }
 
   res.status(httpStatus.OK).send(user.toJSON());

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -21,7 +21,7 @@ const registerUser = catchAsync(async (req, res, next) => {
 
   const userExists = await User.exists({email});
   if (userExists) {
-    return next(new ApiError(httpStatus.BAD_REQUEST, `User ${email} already exists`));
+    return next(new ApiError(httpStatus.BAD_REQUEST, `User ${email} already exists`, {obfuscate: true}));
   }
 
   const userData = {email, firstName, lastName, password, role: UserRole.USER};

--- a/server/src/middleware/errors.ts
+++ b/server/src/middleware/errors.ts
@@ -12,7 +12,7 @@ const errorConverter = (err: Error | ApiError, req: Request, res: Response, next
 
   const statusCode = err instanceof mongoose.Error ? httpStatus.BAD_REQUEST : httpStatus.INTERNAL_SERVER_ERROR;
   const message = String(err.message || httpStatus[statusCode]);
-  next(new ApiError(statusCode, message, false, err.stack));
+  next(new ApiError(statusCode, message, {obfuscate: true, stack: err.stack}));
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -20,7 +20,7 @@ const errorHandler = (err: ApiError, req: Request, res: Response, next: NextFunc
   let {statusCode, message} = err;
   const DEV = config.env === 'development';
 
-  if (!DEV && !err.isOperational) {
+  if (!DEV && err.obfuscate) {
     if (statusCode !== httpStatus.UNAUTHORIZED) {
       statusCode = httpStatus.INTERNAL_SERVER_ERROR;
     }

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -6,9 +6,6 @@ import config from '../config';
 import type {Request, Response, NextFunction} from 'express';
 import {UserRole} from '../types';
 
-const DISCLOSE_MESSAGE = true;
-const OBFUSCATE_MESSAGE = false;
-
 const validate =
   (schema: AnySchema) =>
   (req: Request, res: Response, next: NextFunction): void => {
@@ -16,7 +13,7 @@ const validate =
 
     if (error) {
       const errorMessage = error.details.map((details) => details.message).join(', ');
-      return next(new ApiError(httpStatus.BAD_REQUEST, errorMessage, DISCLOSE_MESSAGE));
+      return next(new ApiError(httpStatus.BAD_REQUEST, errorMessage));
     }
 
     return next();
@@ -24,7 +21,7 @@ const validate =
 
 const checkSession = (req: Request, res: Response, next: NextFunction): void => {
   if (!isLoggedIn(req)) {
-    return next(new ApiError(httpStatus.BAD_REQUEST, `User must be logged in`, DISCLOSE_MESSAGE));
+    return next(new ApiError(httpStatus.BAD_REQUEST, `User must be logged in`));
   }
 
   return next();
@@ -34,7 +31,7 @@ const checkRole =
   (roleExpected: UserRole) =>
   (req: Request, res: Response, next: NextFunction): void => {
     if (roleExpected !== getUserRole(req)) {
-      return next(new ApiError(httpStatus.FORBIDDEN, `Operation is only allowed for ${roleExpected} users`, OBFUSCATE_MESSAGE));
+      return next(new ApiError(httpStatus.FORBIDDEN, `Operation is only allowed for ${roleExpected} users`));
     }
 
     return next();
@@ -44,7 +41,7 @@ const checkBodyForRole =
   (roleExpected: UserRole) =>
   (req: Request, res: Response, next: NextFunction): void => {
     if (req.body.role && roleExpected !== getUserRole(req)) {
-      return next(new ApiError(httpStatus.FORBIDDEN, `Operation is only allowed for ${roleExpected} users`, OBFUSCATE_MESSAGE));
+      return next(new ApiError(httpStatus.FORBIDDEN, `Operation is only allowed for ${roleExpected} users`));
     }
 
     return next();
@@ -55,7 +52,7 @@ const checkEmail = (req: Request, res: Response, next: NextFunction): void => {
   const emailOfLoggedUser = getUserEmail(req);
   if (!emailAddedToRequest || emailAddedToRequest !== emailOfLoggedUser) {
     const mess = `User ${emailOfLoggedUser} is not authorized to perform the operation for user ${emailAddedToRequest}`;
-    return next(new ApiError(httpStatus.FORBIDDEN, mess, OBFUSCATE_MESSAGE));
+    return next(new ApiError(httpStatus.FORBIDDEN, mess, {obfuscate: true}));
   }
 
   return next();

--- a/server/src/utils/apiError.ts
+++ b/server/src/utils/apiError.ts
@@ -1,16 +1,22 @@
+type ApiErrorOptions = {
+  obfuscate?: boolean;
+  stack?: string;
+};
+
 export default class ApiError extends Error {
   public statusCode: number;
   public message: string;
-  public isOperational: boolean;
+  public obfuscate: boolean;
   public stack: string;
 
-  constructor(statusCode: number, message: string, isOperational = false, stack = '') {
+  constructor(statusCode: number, message: string, options?: ApiErrorOptions) {
     super(message);
     this.statusCode = statusCode;
     this.message = message;
-    this.isOperational = isOperational;
-    this.stack = stack;
-    if (!stack) {
+    this.obfuscate = options?.obfuscate || false;
+    this.stack = options?.stack || '';
+
+    if (!options?.stack) {
       Error.captureStackTrace(this, this.constructor);
     }
   }


### PR DESCRIPTION
Most of error messages are helpful for end user and should not be obfuscated. Messages are reviewed to set expected obfuscation depending on info severity.